### PR TITLE
fix: only show live title/favicon/hero for rounds that will be streamed

### DIFF
--- a/src/js/app/events/state.js
+++ b/src/js/app/events/state.js
@@ -192,7 +192,7 @@ const ranked_visible_round_candidates = () => collect_visible_round_candidates_f
 
 const compute_dom_season_timeline = () => {
     const candidates = ranked_visible_round_candidates();
-    const liveCandidate = candidates.find(({ round }) => event_is_streaming(round)) || null;
+    const liveCandidate = candidates.find(({ round, event }) => event_is_streaming(round) && round_will_be_streamed(round, event)) || null;
     const nextCandidate = liveCandidate ? null : (candidates.find(({ round, event }) => event_is_upcoming(round) && round_will_be_streamed(round, event)) || null);
 
     return {


### PR DESCRIPTION
The compute_dom_season_timeline() function now checks round_will_be_streamed() when finding the live candidate, not just event_is_streaming(). This prevents the page title, favicon, and hero section from showing 'Live now' for rounds that are happening but won't actually be streamed.